### PR TITLE
freeze pip version 9.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,7 @@ RUN mkdir -p /opt/flexbar/tmp \
 #Toil#
 ######
 #for now, we pull in the patched versions that tmooney created to fix LSF issues. Once it makes it into a versioned release, these wget lines can be dropped.
-RUN pip install --upgrade pip && \
+RUN pip install --upgrade pip==9.0.1 && \
     pip install toil[cwl]==3.12.0 && \
     cd /tmp/ && \
     wget --no-check-certificate https://raw.githubusercontent.com/tmooney/toil/3.12_lsf_fix/src/toil/batchSystems/lsfHelper.py && \


### PR DESCRIPTION
Latest versions of pip cause an error when the docker hub attempts to create the image. 

```
Step 16/29 : RUN pip install --upgrade pip && pip install toil[cwl]==3.12.0 && cd /tmp/ && wget --no-check-certificate https://raw.githubusercontent.com/tmooney/toil/3.12_lsf_fix/src/toil/batchSystems/lsfHelper.py && mv -f lsfHelper.py /usr/local/lib/python2.7/dist-packages/toil/batchSystems/ && wget --no-check-certificate https://raw.githubusercontent.com/tmooney/toil/3.12_lsf_fix/src/toil/batchSystems/lsf.py && mv -f lsf.py /usr/local/lib/python2.7/dist-packages/toil/batchSystems/ && sed -i 's/select\[type==X86_64 && mem/select[mem/' /usr/local/lib/python2.7/dist-packages/toil/batchSystems/lsf.py
---> Running in dbb2aabaccf6
Collecting pip
Downloading https://files.pythonhosted.org/packages/00/b6/9cfa56b4081ad13874b0c6f96af8ce16cfbc1cb06bedf8e9164ce5551ec1/pip-19.3.1-py2.py3-none-any.whl (1.4MB)
Installing collected packages: pip
Found existing installation: pip 8.1.1
Not uninstalling pip at /usr/lib/python2.7/dist-packages, outside environment /usr
Successfully installed pip-19.3.1
Traceback (most recent call last):
File "/usr/bin/pip", line 9, in <module>
from pip import main
ImportError: cannot import name main
Removing intermediate container dbb2aabaccf6
The command '/bin/sh -c pip install --upgrade pip && pip install toil[cwl]==3.12.0 && cd /tmp/ && wget --no-check-certificate https://raw.githubusercontent.com/tmooney/toil/3.12_lsf_fix/src/toil/batchSystems/lsfHelper.py && mv -f lsfHelper.py /usr/local/lib/python2.7/dist-packages/toil/batchSystems/ && wget --no-check-certificate https://raw.githubusercontent.com/tmooney/toil/3.12_lsf_fix/src/toil/batchSystems/lsf.py && mv -f lsf.py /usr/local/lib/python2.7/dist-packages/toil/batchSystems/ && sed -i 's/select\[type==X86_64 && mem/select[mem/' /usr/local/lib/python2.7/dist-packages/toil/batchSystems/lsf.py' returned a non-zero code: 1
```
freezing pip to version 9.0.1 allows the docker image to be created. version 9.0.1 was used because that is the version of pip currently found in the `latest` docker image
